### PR TITLE
Explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	],
 	"description": "Work with IANA language tags.",
 	"main": "lib/index.js",
+	"type": "commonjs",
 	"homepage": "https://github.com/mattcg/language-tags",
 	"author": "Matthew Caruana Galizia <mattcg@gmail.com>",
 	"repository": {


### PR DESCRIPTION
[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0), which will probably become default in the future. Declaring the type will cause Node to skip detection on startup/compile, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.