### PR TITLE
Remove leftover commonjs directives; update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See the [language-subtag-registry](https://github.com/mattcg/language-subtag-reg
 ## API ##
 
 ```js
-var tags = require('language-tags')
+import tags from 'language-tags'
 ```
 
 Note that all lookups and checks for tags and subtags are case insensitive. For formatting according to common conventions, see `tag.format`.

--- a/lib/Subtag.js
+++ b/lib/Subtag.js
@@ -4,8 +4,6 @@
  * @copyright Copyright (c) 2013, Matthew Caruana Galizia
  */
 
-'use strict';
-
 import index from 'language-subtag-registry/data/json/index.json' with { type: 'json' };
 import registry from 'language-subtag-registry/data/json/registry.json' with { type: 'json' };
 

--- a/lib/Tag.js
+++ b/lib/Tag.js
@@ -4,8 +4,6 @@
  * @copyright Copyright (c) 2013, Matthew Caruana Galizia
  */
 
-'use strict';
-
 import index from 'language-subtag-registry/data/json/index.json' with { type: 'json' };
 import registry from 'language-subtag-registry/data/json/registry.json' with { type: 'json' };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,6 @@
  * @copyright Copyright (c) 2013, Matthew Caruana Galizia
  */
 
-'use strict';
-
 import Tag from './Tag.js';
 import Subtag from './Subtag.js';
 


### PR DESCRIPTION
ESM modules are strict by default, so the `'use strict'` directives are no longer needed.

Likewise, I've updated the example in the readme to use an ESM import rather than a cjs require.