### PR TITLE
fix CI badge in readme

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   pretest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IANA Language Tags for JavaScript #
 
-[![Build Status](https://travis-ci.org/mattcg/language-tags.png?branch=master)](https://travis-ci.org/mattcg/language-tags)
+[![Build Status](https://github.com/mattcg/language-tags/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/mattcg/language-tags/actions/workflows/tests.yml)
 [![Coverage Status](https://coveralls.io/repos/mattcg/language-tags/badge.png)](https://coveralls.io/r/mattcg/language-tags)
 
 Based on [BCP 47](https://www.rfc-editor.org/info/bcp47) ([RFC 5646](https://www.rfc-editor.org/rfc/rfc5646.html)) and the latest [IANA language subtag registry](http://www.iana.org/assignments/language-subtag-registry).


### PR DESCRIPTION
Updated the Build Status badge in the readme to point to GitHub Actions results, as it replaced Travis CI in this repo a while back.

Also bumped `actions/checkout@v4` to its latest major version. Main change is it is now using Node 20 internally instead of 16, which was EOL as of April 2022. Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)