### PR TITLE
Export members individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See the [language-subtag-registry](https://github.com/mattcg/language-subtag-reg
 ## API ##
 
 ```js
-import tags from 'language-tags'
+import {tags, check, subtags, filter, search, languages, language, region, type, date} from 'language-tags'
 ```
 
 Note that all lookups and checks for tags and subtags are case insensitive. For formatting according to common conventions, see `tag.format`.
@@ -23,35 +23,35 @@ Note that all lookups and checks for tags and subtags are case insensitive. For 
 
 Check whether a hyphen-separated tag is valid and well-formed. Always returns a `Tag`, which can be checked using the `valid` method.
 
-### tags.check(tag) ###
+### check(tag) ###
 
 Shortcut for `tags(tag).valid()`. Return `true` if the tag is valid, `false` otherwise. For meaningful error output see `tag.errors()`.
 
-### tags.subtags(subtag), tags.subtags(subtags) ###
+### subtags(subtag), subtags(subtags) ###
 
 Look up one or more subtags. Returns an array of `Subtag` objects. Returns an empty array if all of the subtags are non-existent.
 
-Calling `tags.subtags('mt')` will return an array with two `Subtag` objects: one for Malta (the 'region' type subtag) and one for Maltese (the 'language' type subtag).
+Calling `subtags('mt')` will return an array with two `Subtag` objects: one for Malta (the 'region' type subtag) and one for Maltese (the 'language' type subtag).
 
 ```
-> tags.subtags('mt');
+> subtags('mt');
 [Subtag, Subtag]
-> tags.subtags('bumblebee');
+> subtags('bumblebee');
 []
 ```
 
-To get or check a single subtag by type use `tags.language(subtag)`, `tags.region(subtag)` or `tags.type(subtag, type)`.
+To get or check a single subtag by type use `language(subtag)`, `region(subtag)` or `type(subtag, type)`.
 
-### tags.filter(subtags) ###
+### filter(subtags) ###
 
-The opposite of `tags.subtags(subtags)`. Returns an array of codes that are not registered subtags, otherwise returns an empty array.
+The opposite of `subtags(subtags)`. Returns an array of codes that are not registered subtags, otherwise returns an empty array.
 
 ```
-> tags.filter(['en', 'Aargh']);
+> filter(['en', 'Aargh']);
 ['Aargh']
 ```
 
-### tags.search(description, [all]) ###
+### search(description, [all]) ###
 
 Search for tags and subtags by description. Supports either a RegExp object or a string for `description`. Returns an array of `Subtag` and `Tag` objects or an empty array if no results were found.
 
@@ -59,60 +59,60 @@ Note that `Tag` objects in the results represent 'grandfathered' or 'redundant' 
 
 Search is case-insensitive if `description` is a string.
 
-### tags.languages(macrolanguage) ###
+### languages(macrolanguage) ###
 
 Returns an array of `Subtag` objects representing all the 'language' type subtags belonging to the given 'macrolanguage' type subtag.
 
 Throws an error if `macrolanguage` is not a macrolanguage.
 
 ```
-> tags.languages('zh');
+> languages('zh');
 [Subtag, Subtag...]
-> tags.languages('en');
+> languages('en');
 Error: 'en' is not a valid macrolanguage.
 ```
 
-### tags.language(subtag) ###
+### language(subtag) ###
 
 Convenience method to get a single 'language' type subtag. Can be used to validate an input value as a language subtag. Returns a `Subtag` object or `null`.
 
 ```
-> tags.language('en');
+> language('en');
 Subtag
-> tags.language('us');
+> language('us');
 null
 ```
 
-### tags.region(subtag) ###
+### region(subtag) ###
 
 As above, but with 'region' type subtags.
 
 ```
-> tags.region('mt');
+> region('mt');
 Subtag
-> tags.region('en');
+> region('en');
 null
 ```
 
-### tags.type(subtag, type) ###
+### type(subtag, type) ###
 
 Get a subtag by type. Returns the subtag matching `type` as a `Subtag` object otherwise returns `null`.
 
 A `type` consists of one of the following strings: 'language', 'extlang', 'script', 'region' or 'variant'. To get a 'grandfathered' or 'redundant' type tag use `tags(tag)`.
 
 ```
-> tags.type('zh', 'macrolanguage');
+> type('zh', 'macrolanguage');
 Subtag
-> tags.type('zh', 'script');
+> type('zh', 'script');
 null
 ```
 
-### tags.date() ###
+### date() ###
 
 Returns the file date for the underlying data, as a string.
 
 ```
-> tags.date();
+> date();
 '2004-06-28'
 ```
 
@@ -127,7 +127,7 @@ Get the subtag type (either 'language', 'extlang', 'script', 'region' or 'varian
 Returns an array of description strings (a subtag may have more than one description).
 
 ```
-> tags.language('ro').descriptions();
+> language('ro').descriptions();
 ['Romanian', 'Moldavian', 'Moldovan']
 ```
 
@@ -136,7 +136,7 @@ Returns an array of description strings (a subtag may have more than one descrip
 Returns a preferred subtag as a `Subtag` object if the subtag is deprecated. For example, `ro` is preferred over deprecated `mo`.
 
 ```
-> tags.language('mo').preferred();
+> language('mo').preferred();
 Subtag
 ```
 
@@ -148,12 +148,12 @@ For subtags of type 'language' or 'extlang', returns a `Subtag` object represent
 
 Returns the subtag scope as a string, or `null` if the subtag has no scope.
 
-Tip: if the subtag represents a macrolanguage, you can use `tags.languages(macrolanguage)` to get a list of all the macrolanguage's individual languages.
+Tip: if the subtag represents a macrolanguage, you can use `languages(macrolanguage)` to get a list of all the macrolanguage's individual languages.
 
 ```
-> tags.language('zh').scope();
+> language('zh').scope();
 'macrolanguage'
-> tags.language('nah').scope();
+> language('nah').scope();
 'collection'
 ```
 
@@ -162,7 +162,7 @@ Tip: if the subtag represents a macrolanguage, you can use `tags.languages(macro
 Returns a date string reflecting the deprecation date if the subtag is deprecated, otherwise returns `null`.
 
 ```
-> tags.language('ja').deprecated();
+> language('ja').deprecated();
 '2008-11-22'
 ```
 
@@ -171,7 +171,7 @@ Returns a date string reflecting the deprecation date if the subtag is deprecate
 Returns a date string reflecting the date the subtag was added to the registry.
 
 ```
-> tags.language('ja').added();
+> language('ja').added();
 '2005-10-16'
 ```
 
@@ -180,7 +180,7 @@ Returns a date string reflecting the date the subtag was added to the registry.
 Returns an array of comments, if any, otherwise returns an empty array.
 
 ```
-> tags.language('nmf').comments();
+> language('nmf').comments();
 ['see ntx']
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,17 +12,15 @@ import registry from 'language-subtag-registry/data/json/registry.json' with { t
 import meta from 'language-subtag-registry/data/json/meta.json' with { type: 'json' };
 import macrolanguages from 'language-subtag-registry/data/json/macrolanguage.json' with { type: 'json' };
 
-const tags = function(tag) {
+export function tags(tag) {
 	return new Tag(tag);
 };
 
-export default tags;
-
-tags.check = function(tag) {
+export function check(tag) {
 	return new Tag(tag).valid();
 };
 
-tags.types = function(subtag) {
+export function types(subtag) {
 	var types = index[subtag.toLowerCase()];
 
 	if (!types) {
@@ -34,7 +32,7 @@ tags.types = function(subtag) {
 	});
 };
 
-tags.subtags = function(subtags) {
+export function subtags(subtags) {
 	var result = [];
 
 	if (!Array.isArray(subtags)) {
@@ -42,7 +40,7 @@ tags.subtags = function(subtags) {
 	}
 
 	subtags.forEach(function(subtag) {
-		tags.types(subtag).forEach(function(type) {
+		types(subtag).forEach(function(type) {
 			result.push(new Subtag(subtag, type));
 		});
 	});
@@ -50,13 +48,13 @@ tags.subtags = function(subtags) {
 	return result;
 };
 
-tags.filter = function(subtags) {
+export function filter(subtags) {
 	return subtags.filter(function(subtag) {
-		return !tags.types(subtag).length;
+		return !types(subtag).length;
 	});
 };
 
-tags.search = function(query, all) {
+export function search(query, all) {
 	var test;
 
 	if ('function' === typeof query.test) {
@@ -99,7 +97,7 @@ tags.search = function(query, all) {
 	});
 };
 
-tags.languages = function(macrolanguage) {
+export function languages(macrolanguage) {
 	var i, l, record, results = [];
 
 	macrolanguage = macrolanguage.toLowerCase();
@@ -117,15 +115,15 @@ tags.languages = function(macrolanguage) {
 	return results;
 };
 
-tags.language = function(subtag) {
-	return tags.type(subtag, 'language');
+export function language(subtag) {
+	return type(subtag, 'language');
 };
 
-tags.region = function(subtag) {
-	return tags.type(subtag, 'region');
+export function region(subtag) {
+	return type(subtag, 'region');
 };
 
-tags.type = function(subtag, type) {
+export function type(subtag, type) {
 	var types = typeof subtag === 'string' && index[subtag.toLowerCase()];
 
 	if (types && types[type]) {
@@ -135,6 +133,19 @@ tags.type = function(subtag, type) {
 	return null;
 };
 
-tags.date = function() {
+export function date() {
 	return meta['File-Date'];
 };
+
+// todo: remove in v3
+tags.check = check;
+tags.types = types;
+tags.subtags = subtags;
+tags.filter = filter;
+tags.search = search;
+tags.languages = languages;
+tags.language = language;
+tags.region = region;
+tags.type = type;
+tags.date = date;
+export default tags;

--- a/test/src/index-test.js
+++ b/test/src/index-test.js
@@ -8,58 +8,58 @@
 
 import assert from 'assert';
 import {describe, it} from 'mocha';
-import tags from '../../lib/index.js';
+import {date, type, region, language, languages, search, subtags, check, tags} from '../../lib/index.js';
 
 describe('tags', function () {
 	it('date() returns file date', function() {
-		assert(/\d{4}\-\d{2}\-\d{2}/.test(tags.date()));
+		assert(/\d{4}\-\d{2}\-\d{2}/.test(date()));
 	});
 
 	it('type() returns subtag by type', function() {
 		var subtag;
 
-		subtag = tags.type('Latn', 'script');
+		subtag = type('Latn', 'script');
 		assert(subtag);
 		assert.equal(subtag.format(), 'Latn');
 		assert.equal(subtag.type(), 'script');
 
-		assert.equal(tags.type('en', 'script'), null);
+		assert.equal(type('en', 'script'), null);
 	});
 
 	it('region() returns subtag by region', function() {
 		var subtag;
 
-		subtag = tags.region('IQ');
+		subtag = region('IQ');
 		assert(subtag);
 		assert.equal(subtag.format(), 'IQ');
 		assert.equal(subtag.type(), 'region');
 
-		assert.equal(tags.region('en'), null);
+		assert.equal(region('en'), null);
 	});
 
     it('language() handles undefined argument', function() {
-        assert.ifError(tags.language(undefined));
+        assert.ifError(language(undefined));
     });
 
 	it('language() returns subtag by language', function() {
 		var subtag;
 
-		subtag = tags.language('en');
+		subtag = language('en');
 		assert(subtag);
 		assert.equal(subtag.format(), 'en');
 		assert.equal(subtag.type(), 'language');
 
-		assert.equal(tags.language('GB'), null);
+		assert.equal(language('GB'), null);
 	});
 
 	it('languages() returns all languages for macrolanguage', function() {
 		var subtags, err;
 
-		subtags = tags.languages('zh');
+		subtags = languages('zh');
 		assert(subtags.length > 0);
 
 		try {
-			assert.equal(tags.languages('en'));
+			assert.equal(languages('en'));
 		} catch (e) {
 			err = e;
 		}
@@ -71,7 +71,7 @@ describe('tags', function () {
 	it('search() matches descriptions', function() {
 		var subtags;
 
-		subtags = tags.search('Maltese');
+		subtags = search('Maltese');
 		assert(subtags.length > 0);
 
 		assert.equal(subtags[0].type(), 'language');
@@ -81,14 +81,14 @@ describe('tags', function () {
 		assert.equal(subtags[2].type(), 'extlang');
 		assert.equal(subtags[2].format(), 'mdl');
 
-		subtags = tags.search('Gibberish');
+		subtags = search('Gibberish');
 		assert.deepEqual(subtags, []);
 	});
 
 	it('search() puts exact match at the top', function() {
 		var subtags;
 
-		subtags = tags.search('Dari');
+		subtags = search('Dari');
 		assert(subtags.length > 0);
 
 		assert.equal(subtags[0].type(), 'language');
@@ -96,32 +96,32 @@ describe('tags', function () {
 	});
 
 	it('subtags() returns subtags', function() {
-		var subtags;
+		var subtags2;
 
-		subtags = tags.subtags('whatever');
-		assert.deepEqual(subtags, []);
+		subtags2 = subtags('whatever');
+		assert.deepEqual(subtags2, []);
 
-		subtags = tags.subtags('mt');
-		assert.equal(subtags.length, 2);
-		assert.equal(subtags[0].type(), 'language');
-		assert.equal(subtags[0].format(), 'mt');
-		assert.equal(subtags[1].type(), 'region');
-		assert.equal(subtags[1].format(), 'MT');
+		subtags2 = subtags('mt');
+		assert.equal(subtags2.length, 2);
+		assert.equal(subtags2[0].type(), 'language');
+		assert.equal(subtags2[0].format(), 'mt');
+		assert.equal(subtags2[1].type(), 'region');
+		assert.equal(subtags2[1].format(), 'MT');
 	});
 
 	it('subtags() is case insensitive', function() {
-		var subtags;
+		var subtags2;
 
 		// Test for issue #11.
-		subtags = tags.subtags('SgNw')
-		assert.equal(subtags.length, 1);
-		assert.equal(subtags[0].type(), 'script');
-		assert.equal(subtags[0].format(), 'Sgnw');
+		subtags2 = subtags('SgNw')
+		assert.equal(subtags2.length, 1);
+		assert.equal(subtags2[0].type(), 'script');
+		assert.equal(subtags2[0].format(), 'Sgnw');
 	});
 
 	it('check() checks tag validity', function() {
-		assert(tags.check('en'));
-		assert(!tags.check('mo'));
+		assert(check('en'));
+		assert(!check('mo'));
 	});
 
 	it('gets tag', function() {


### PR DESCRIPTION
This adds first-class individual named exports to the ES6 module which is more idiomatic and efficient.

The old default export with attached properties is preserved to make this a non-breaking change that can be merged in the next minor version, and can be removed in the next major version.